### PR TITLE
rbuildignore - dot to escaped dot

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -4,5 +4,5 @@
 ^Jenkinsfile$
 data_raw/*
 README.*
-^staged_dependencies.yaml$
+^staged_dependencies\.yaml$
 ^LICENSE\.md$


### PR DESCRIPTION
Update .Rbuildignore for ^stage_dependencies\\.yaml$.

Dot was not escaped