### PR TITLE
Remove teal.data

### DIFF
--- a/staged_dependencies.yaml
+++ b/staged_dependencies.yaml
@@ -9,9 +9,6 @@ downstream_repos:
   insightsengineering/teal:
     repo: insightsengineering/teal
     host: https://github.com
-  insightsengineering/teal.data:
-    repo: insightsengineering/teal.data
-    host: https://github.com
   insightsengineering/teal.transform:
     repo: insightsengineering/teal.transform
     host: https://github.com


### PR DESCRIPTION
Removes `teal.data` as a downstream dependency.

Part of insightsengineering/teal.data#111
