### PR TITLE
remove tmc

### DIFF
--- a/staged_dependencies.yaml
+++ b/staged_dependencies.yaml
@@ -21,9 +21,6 @@ downstream_repos:
   insightsengineering/teal.modules.general:
     repo: insightsengineering/teal.modules.general
     host: https://github.com
-  insightsengineering/teal.modules.clinical:
-    repo: insightsengineering/teal.modules.clinical
-    host: https://github.com
   insightsengineering/osprey:
     repo: insightsengineering/osprey
     host: https://github.com


### PR DESCRIPTION
Removes `teal.modules.clinical` as a downstream dependency.

Part of https://github.com/insightsengineering/teal.modules.clinical/pull/659
